### PR TITLE
Fix typo in rtorrent idempotentConfig

### DIFF
--- a/scripts/lib/rtorrentConfig.php
+++ b/scripts/lib/rtorrentConfig.php
@@ -110,7 +110,7 @@ class rtorrentConfig {
 	public function idempotentConfig($user, $config) {
 		$file = '/home/' . $user . '/.rtorrent.rc';
 		#TODO Check mtime + permissions first. if root and no "other" write permission + mtime exceeds 2-3 months, we can be 99.9% certain it's right
-		$data = file_get_contets( $file );
+                $data = file_get_contents( $file );
 		
 		if ($data !== $config) return $this->writeConfig($user, $config);
 	}


### PR DESCRIPTION
## Summary
- fix spelling of `file_get_contents` in `idempotentConfig`

## Testing
- `php -l scripts/lib/rtorrentConfig.php`
- `php -r 'require "scripts/lib/rtorrentConfig.php"; $cfg = new rtorrentConfig(array("ramBlock"=>250,"peers"=>array("minimum"=>6,"maximum"=>32),"uploadSlots"=>7),"template"); $cfg->idempotentConfig("testuser", "config"); echo "done";'`

------
https://chatgpt.com/codex/tasks/task_e_6872747bcb58832f9a6e8e11174ddc14