### PR TITLE
Fix parameter handling and typos

### DIFF
--- a/scripts/addUser.php
+++ b/scripts/addUser.php
@@ -13,14 +13,14 @@ $user = array(
     'quota'     => $argv[4]    
 );
 if (isset($argv[5])) $user['trafficLimit'] = (int) $argv[5];
-if ($user['password'] == 'rand') $user['password'] == '';
+if ($user['password'] == 'rand') $user['password'] = '';
     
 require_once 'lib/rtorrentConfig.php';
 require_once 'lib/users.php';
 $userDb = new users();
 
 // Get our server hostname, and do some cleanup just to be safe
-$hostname = trim( file_get_contents('/etc/hostname') );;
+$hostname = trim( file_get_contents('/etc/hostname') );
 $hostname = str_replace(array("\n", "\r", "\t"), array('','',''), $hostname);
 
 

--- a/scripts/lib/serverApi.php
+++ b/scripts/lib/serverApi.php
@@ -144,10 +144,10 @@ class remoteServerApi {
         ****/
         
         $commandMap = array(
-            'addUser' => array('execute' => '/scripts/addUser.php', 'params' => array('username', 'password', 'memory', 'ram') ),
+            'addUser'       => array('execute' => '/scripts/addUser.php',       'params' => array('username', 'password', 'memory', 'quota') ),
             'terminateUser' => array('execute' => '/scripts/terminateUser.php', 'params' => array('username', 'batch' => '--batch') ),
-            'setupNetwork' => array('execute' => '/scripts/util/setupNetwork.php', 'params' => array()),
-            'recreateUser' => array('execute' => '/scripts/recreateUser.php', 'params' => array('username', 'memory', 'ram') )
+            'setupNetwork'  => array('execute' => '/scripts/util/setupNetwork.php', 'params' => array()),
+            'recreateUser'  => array('execute' => '/scripts/recreateUser.php',  'params' => array('username', 'memory', 'quota') )
         );
         
         if (!isset( $commandMap[ $command ] ) ) {
@@ -159,14 +159,14 @@ class remoteServerApi {
         $useParams = array();
         foreach($requiredParams AS $thisParam => $thisValue) {
             if (!empty($thisValue)) {
-                $useParams[ $thisValue ];
+                $useParams[] = $thisValue;
                 continue;   // "Forced" value, always present at this spot
             }
             if (!$parameters[ $thisParam ]) {
-                $this->_lob('calls', "Job: {$callId} failed due to missing parameter {$thisParam}");
+                $this->_log('calls', "Job: {$callId} failed due to missing parameter {$thisParam}");
                 return false;
             }
-            $useParams[ $parameters[ $thisParam ] ];    // Add parameter to be used
+            $useParams[] = $parameters[ $thisParam ];    // Add parameter to be used
         }
         
         $commandExecute = $commandMap[ $command ]['execute'] . implode(' ', $useParams);


### PR DESCRIPTION
## Summary
- map quota parameter correctly in server API commands
- clean up hostname assignment in `addUser.php`

## Testing
- `php -l scripts/lib/serverApi.php`
- `php -l scripts/addUser.php`


------
https://chatgpt.com/codex/tasks/task_e_6872730284c4832f98ecdef67c125dad