### PR TITLE
Improve update-step2 docs and version tracking

### DIFF
--- a/etc/seedbox/config/template.motd
+++ b/etc/seedbox/config/template.motd
@@ -14,6 +14,7 @@ Network Speed: %NETWORK_SPEED%
 
 
 PMSS Version: %PMSS_VERSION%
+Runtime Version: %RUN_VERSION%
 Last Update: %UPDATE_DATE%  APT Update/Upgrade: %APT_LAST_UPDATE%
 Kernel: %KERNEL_VERSION%
 

--- a/scripts/lib/update.php
+++ b/scripts/lib/update.php
@@ -185,3 +185,17 @@ function getDistroVersion() {
     }
     return '';
 }
+
+/**
+ * Retrieve current PMSS version from the configured version file.
+ *
+ * @param string $versionFile Path to the version file.
+ *
+ * @return string The version string or "unknown" if not found.
+ */
+function getPmssVersion($versionFile = '/etc/seedbox/config/version') {
+    if (file_exists($versionFile) && filesize($versionFile) > 0) {
+        return trim(file_get_contents($versionFile));
+    }
+    return 'unknown';
+}


### PR DESCRIPTION
## Summary
- document dynamic update-step2 entry
- factor PMSS version retrieval into lib/update.php
- track runtime version in /var/run/pmss/version
- show runtime version in MOTD template
- refine comments and fix typos in update-step2

## Testing
- `php -l scripts/util/update-step2.php`
- `php -l scripts/lib/update.php`


------
https://chatgpt.com/codex/tasks/task_e_6872764dd704832fb8acdfcabe97b3c0