### PR TITLE
Add port manager docs and integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@
 
 ## end of var
 
+# Documentation
+!/docs/
+!/docs/*
+
 # Additionally, do not ignore .gitignore file itself
 !.gitignore
 

--- a/docs/portManager.md
+++ b/docs/portManager.md
@@ -1,0 +1,21 @@
+# Port Management Utility
+
+The `portManager.php` script is used to manage HTTP server port assignments for user services.
+
+```
+Usage: portManager.php [view|assign|release] USER [SERVICE]
+```
+
+- **view** – show the assigned port
+- **assign** – allocate a free port (if none assigned)
+- **release** – free the port assignment
+
+Port information is stored under `/etc/seedbox/runtime/ports` using files named `SERVICE-USER`.
+
+Example:
+
+```
+/scripts/util/portManager.php assign alice lighttpd
+/scripts/util/portManager.php view alice lighttpd
+/scripts/util/portManager.php release alice lighttpd
+```

--- a/scripts/addUser.php
+++ b/scripts/addUser.php
@@ -43,6 +43,9 @@ $userDb->addUser( $user['name'], array(
     'suspended' => false
 ));
 
+// Assign HTTP server port
+passthru("/scripts/util/portManager.php assign {$user['name']} lighttpd");
+
 // Configure quota, rtorrent and ruTorrent.
 passthru('/scripts/util/userConfig.php "' . $user['name'] . '" "' . $user['memory'] . '" "' . $user['quota'] . '"');
 

--- a/scripts/terminateUser.php
+++ b/scripts/terminateUser.php
@@ -45,7 +45,7 @@ passthru("userdel {$username}; groupdel {$username};"); // If during first attem
                                         //Make sure by attempting again FURTHER group needs to be deleted as well
 passthru("rm -rf /var/run/screen/S-{$username}");
 passthru("rm -rf /home/{$username} /etc/nginx/users/{$username}");
-unlink("/etc/seedbox/runtime/ports/lighttpd-{$username}");
+passthru("/scripts/util/portManager.php release {$username} lighttpd");
 unlink("/etc/nginx/users/{$username}");
 
 // If attemps 1 and 2 failed ...

--- a/scripts/util/configureLighttpd.php
+++ b/scripts/util/configureLighttpd.php
@@ -31,10 +31,8 @@ foreach($users AS $thisUser) {
     if (file_exists($portFile)) {
         $serverPort = (int) file_get_contents($portFile);
     } else {
-        #TODO command line script to set the port
-		#TODO and check that no one else uses the same, doh!
-        $serverPort = (int) rand(2000,38000);
-        file_put_contents($portFile, $serverPort);
+        // Allocate a unique port using portManager utility
+        $serverPort = (int) trim(shell_exec("/scripts/util/portManager.php assign {$thisUser} lighttpd"));
     }
     
     

--- a/scripts/util/portManager.php
+++ b/scripts/util/portManager.php
@@ -1,0 +1,46 @@
+#!/usr/bin/php
+<?php
+$usage = "Usage: portManager.php [view|assign|release] USER [SERVICE]\n";
+if ($argc < 3) die($usage);
+$action = strtolower($argv[1]);
+$user   = $argv[2];
+$service = isset($argv[3]) ? $argv[3] : 'lighttpd';
+$portDir = '/etc/seedbox/runtime/ports';
+if (!file_exists($portDir)) mkdir($portDir, 0755, true);
+$portFile = "$portDir/{$service}-{$user}";
+
+switch ($action) {
+    case 'view':
+        if (file_exists($portFile)) {
+            echo trim(file_get_contents($portFile)) . "\n";
+        } else echo "No port assigned\n";
+        break;
+
+    case 'assign':
+        if (file_exists($portFile)) {
+            echo trim(file_get_contents($portFile)) . "\n";
+            break;
+        }
+        $used = [];
+        foreach (glob("$portDir/{$service}-*") as $f) {
+            $p = (int) trim(@file_get_contents($f));
+            if ($p) $used[$p] = true;
+        }
+        do {
+            $port = rand(2000, 38000);
+        } while (isset($used[$port]));
+        file_put_contents($portFile, $port);
+        chmod($portFile, 0640);
+        echo $port . "\n";
+        break;
+
+    case 'release':
+        if (file_exists($portFile)) {
+            unlink($portFile);
+            echo "Port released\n";
+        } else echo "No port assigned\n";
+        break;
+    default:
+        die($usage);
+}
+?>


### PR DESCRIPTION
## Summary
- document port management utility in `docs/portManager.md`
- remove the earlier README section
- use the new utility when configuring lighttpd
- track documentation via `.gitignore`

## Testing
- `php -l scripts/util/portManager.php`
- `php -l scripts/addUser.php`
- `php -l scripts/terminateUser.php`
- `php -l scripts/util/configureLighttpd.php`


------
https://chatgpt.com/codex/tasks/task_e_68727b0dc1a4832fa8ca356d0bf4f670