### PR TITLE
Refactor userPermissions script

### DIFF
--- a/scripts/util/userPermissions.php
+++ b/scripts/util/userPermissions.php
@@ -10,36 +10,72 @@ if (!file_exists("/home/{$thisUser}")) die("User does not exist\n");
 $userList = file_get_contents('/etc/passwd');
 if (strpos($userList, $thisUser) === false) die("No such user\n");
 
-    `find /home/{$thisUser}/ -type d|xargs -n1 -d "\n" chmod 750`;
-    `chmod 770 /home/{$thisUser}`;
-    `chmod 640 /home/{$thisUser}/.viminfo`;
-    `chmod 640 /home/{$thisUser}/.quota`;
-    `chmod 640 /home/{$thisUser}/.profile`;
-    `chmod 640 /home/{$thisUser}/.bash_history`;
-    `chmod 640 /home/{$thisUser}/.bashrc`;
-    `chmod 770 /home/{$thisUser}/.tmp`;
-    `chmod 770 /home/{$thisUser}/.config -R`;
-    `chmod 640 /home/{$thisUser}/.trafficData`;
-    `chmod 644 /home/{$thisUser}/.rtorrent.rc`;
-    `chmod 750 /home/{$thisUser}/watch -R`;
-    `chmod 750 /home/{$thisUser}/session -R`;
-    `chmod 750 /home/{$thisUser}/data -R`;
-    `chmod 750 /home/{$thisUser}/www -R`;
-    `chmod 750 /home/{$thisUser}/.*.php`;
-    `chmod 775 /home/{$thisUser}/.lighttpd`;
-    `chmod 754 /home/{$thisUser}/.lighttpd/.htpasswd`;
-    `chmod 770 /home/{$thisUser}/.lighttpd/compress`;
-    `chmod 770 /home/{$thisUser}/.lighttpd/upload`;
-    `chown {$thisUser}.{$thisUser} /home/{$thisUser}/.lighttpd/.htpasswd`;
-    `chown {$thisUser}.{$thisUser} /home/{$thisUser}/.lighttpd/ -R`;
-    `chown {$thisUser}.{$thisUser} /home/{$thisUser}/ -R`;
-    `chown {$thisUser}.{$thisUser} /home/{$thisUser}/www/rutorrent/share/users/{$thisUser}/settings`;
-    `chown {$thisUser}.{$thisUser} /home/{$thisUser}/www/rutorrent/share/users/{$thisUser}/settings/retrackers.dat`;
-    `chown {$thisUser}.{$thisUser} /home/{$thisUser}/www/rutorrent/share/users/{$thisUser}`;
-    `chown {$thisUser}.{$thisUser} /home/{$thisUser}/www/rutorrent/share/users/{$thisUser}/torrents`;
-    `chown root.root /home/{$thisUser}/.rtorrent.rc`;
-    `chown root.root /home/{$thisUser}/www/rutorrent/conf/config.php`;
-    `chmod 754 /home/{$thisUser}/www/rutorrent/conf/config.php`;
-    `chmod 750 /home/{$thisUser}/.irssi`;
-    `chmod 750 /home/{$thisUser}/.sync`;
-    (file_exists("/home/{$thisUser}/.ssh") ? `chmod 750 /home/{$thisUser}/.ssh` : '');
+function run(string $cmd): void
+{
+    shell_exec($cmd);
+}
+
+function chmodPath(string $path, int $perm, bool $recursive = false): void
+{
+    $flag = $recursive ? '-R ' : '';
+    $target = strpbrk($path, '*?[]') === false ? escapeshellarg($path) : $path;
+    run(sprintf('chmod %s%o %s', $flag, $perm, $target));
+}
+
+function chownPath(string $path, string $owner, bool $recursive = false): void
+{
+    $flag = $recursive ? '-R ' : '';
+    $target = strpbrk($path, '*?[]') === false ? escapeshellarg($path) : $path;
+    run("chown {$flag}{$owner} {$target}");
+}
+
+run('find /home/' . escapeshellarg($thisUser) . ' -type d|xargs -n1 -d "\n" chmod 750');
+
+$chmodItems = [
+    ["/home/{$thisUser}", 0770],
+    ["/home/{$thisUser}/.viminfo", 0640],
+    ["/home/{$thisUser}/.quota", 0640],
+    ["/home/{$thisUser}/.profile", 0640],
+    ["/home/{$thisUser}/.bash_history", 0640],
+    ["/home/{$thisUser}/.bashrc", 0640],
+    ["/home/{$thisUser}/.tmp", 0770],
+    ["/home/{$thisUser}/.config", 0770, true],
+    ["/home/{$thisUser}/.trafficData", 0640],
+    ["/home/{$thisUser}/.rtorrent.rc", 0644],
+    ["/home/{$thisUser}/watch", 0750, true],
+    ["/home/{$thisUser}/session", 0750, true],
+    ["/home/{$thisUser}/data", 0750, true],
+    ["/home/{$thisUser}/www", 0750, true],
+    ["/home/{$thisUser}/.*.php", 0750],
+    ["/home/{$thisUser}/.lighttpd", 0775],
+    ["/home/{$thisUser}/.lighttpd/.htpasswd", 0754],
+    ["/home/{$thisUser}/.lighttpd/compress", 0770],
+    ["/home/{$thisUser}/.lighttpd/upload", 0770],
+    ["/home/{$thisUser}/www/rutorrent/conf/config.php", 0754],
+    ["/home/{$thisUser}/.irssi", 0750],
+    ["/home/{$thisUser}/.sync", 0750],
+];
+
+$chownItems = [
+    ["/home/{$thisUser}/.lighttpd/.htpasswd", "{$thisUser}.{$thisUser}"],
+    ["/home/{$thisUser}/.lighttpd/", "{$thisUser}.{$thisUser}", true],
+    ["/home/{$thisUser}/", "{$thisUser}.{$thisUser}", true],
+    ["/home/{$thisUser}/www/rutorrent/share/users/{$thisUser}/settings", "{$thisUser}.{$thisUser}"],
+    ["/home/{$thisUser}/www/rutorrent/share/users/{$thisUser}/settings/retrackers.dat", "{$thisUser}.{$thisUser}"],
+    ["/home/{$thisUser}/www/rutorrent/share/users/{$thisUser}", "{$thisUser}.{$thisUser}"],
+    ["/home/{$thisUser}/www/rutorrent/share/users/{$thisUser}/torrents", "{$thisUser}.{$thisUser}"],
+    ["/home/{$thisUser}/.rtorrent.rc", "root.root"],
+    ["/home/{$thisUser}/www/rutorrent/conf/config.php", "root.root"],
+];
+
+foreach ($chmodItems as [$path, $perm, $recursive]) {
+    chmodPath($path, $perm, $recursive ?? false);
+}
+
+foreach ($chownItems as [$path, $owner, $recursive]) {
+    chownPath($path, $owner, $recursive ?? false);
+}
+
+if (file_exists("/home/{$thisUser}/.ssh")) {
+    chmodPath("/home/{$thisUser}/.ssh", 0750);
+}


### PR DESCRIPTION
## Summary
- refactor `userPermissions.php` to reduce duplication
- add permission and ownership arrays and helper functions

## Testing
- `php -l scripts/util/userPermissions.php`
- `find scripts -name '*.php' ! -name 'watchdog.php' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68727b3fc640832fa2a332f1d707a417