### PR TITLE
Add docs for common admin scripts

### DIFF
--- a/docs/addUser.md
+++ b/docs/addUser.md
@@ -1,0 +1,31 @@
+# Adding a New User
+
+The `addUser.php` script provisions a seedbox account with the required quota and rTorrent settings.
+
+```
+Usage: addUser.php USERNAME PASSWORD MAX_RTORRENT_MEMORY_IN_MB DISK_QUOTA_IN_GB [trafficLimitGB]
+```
+
+Arguments:
+- **USERNAME** – login name to create
+- **PASSWORD** – set the initial password (use `rand` for a random password)
+- **MAX_RTORRENT_MEMORY_IN_MB** – memory limit applied to rTorrent
+- **DISK_QUOTA_IN_GB** – storage quota
+- **trafficLimitGB** (optional) – monthly traffic cap
+
+On success the script:
+- creates the Unix user and home directory
+- assigns an HTTP service port via `portManager.php`
+- writes rTorrent/ruTorrent configuration
+- enables quotas and traffic limits
+- starts rTorrent and lighttpd
+
+Example:
+
+```
+/scripts/addUser.php alice rand 512 100 500
+```
+
+This adds user `alice` with a random password, 512 MB rTorrent limit, 100 GB disk quota and a 500 GB monthly traffic limit.
+
+**Documentation quality**: The script itself is largely uncommented and could benefit from a more detailed explanation of the setup steps performed.

--- a/docs/setupLetsEncrypt.md
+++ b/docs/setupLetsEncrypt.md
@@ -1,0 +1,17 @@
+# Let's Encrypt Setup
+
+`setupLetsEncrypt.php` obtains an SSL certificate for the server hostname using Certbot.
+
+```
+/scripts/util/setupLetsEncrypt.php you@example.com
+```
+
+The script expects a valid email address as its only parameter. It will:
+- install Certbot (using the distribution package or a Python virtualenv on Debian 10)
+- request a certificate for the host returned by `hostname`
+- schedule automatic renewal via cron
+- regenerate the Nginx configuration
+
+Run this after setting the correct DNS records for the hostname.
+
+**Documentation quality**: The script contains minimal comments. Notes on supported distributions and certificate paths would improve clarity.

--- a/docs/setupNetwork.md
+++ b/docs/setupNetwork.md
@@ -1,0 +1,19 @@
+# Network Configuration Script
+
+`setupNetwork.php` applies firewall and traffic shaping rules for all seedbox users. It reads settings from `/etc/seedbox/config/network` and optional `/etc/seedbox/config/localnet`.
+
+There are no command line arguments; simply run:
+
+```
+/scripts/util/setupNetwork.php
+```
+
+Actions performed include:
+- installing iptables monitoring rules
+- enabling forwarding and NAT for VPN tunnels
+- filtering bogon networks
+- generating a FireQOS configuration for user bandwidth limits
+
+This script is usually run after user modifications or during system updates.
+
+**Documentation quality**: The code implements many networking tweaks but lacks inline comments or a high level overview. More documentation on expected config values would be beneficial.

--- a/docs/update.md
+++ b/docs/update.md
@@ -1,0 +1,31 @@
+# Update Workflow
+
+PMSS uses a two‑phase updater. The main entry point is `update.php`, which refreshes the scripts from GitHub and then invokes `util/update-step2.php` for configuration changes.
+
+```
+/scripts/update.php [<source-spec>] [--scriptonly] [--verbose]
+```
+
+`<source-spec>` defines what to update to. Examples from the script header:
+
+```
+release                  # latest GitHub release
+release:2025-07-12       # explicit tag
+git/main                 # branch "main" from default repo
+git/dev:2024-12-05       # branch "dev" pinned to a past date
+git/https://url/repo.git:beta[:2025-01-01]  # custom repo
+```
+
+Options:
+- **--scriptonly** – download and deploy the scripts without running phase 2
+- **--verbose** – print debug information
+
+After copying files, phase 2 (`update-step2.php`) performs system-level tasks such as package installation, configuration tweaks and user environment updates.
+
+Example for upgrading to the current release:
+
+```
+/scripts/update.php release
+```
+
+**Documentation quality**: The update process is extensive and only partially documented in comments. Additional user-facing notes on rollback and expected downtime would be helpful.

--- a/docs/userConfig.md
+++ b/docs/userConfig.md
@@ -1,0 +1,24 @@
+# Adjusting User Settings
+
+`userConfig.php` modifies an existing account's resource limits and service configuration.
+
+```
+Usage: ./userConfig.php USERNAME MAX_RAM_MB DISK_QUOTA_IN_GB [TRAFFIC_LIMIT_GB] [CPUWEIGHT=1000] [IOWEIGHT=1000]
+```
+
+Parameters:
+- **USERNAME** – user to update
+- **MAX_RAM_MB** – memory limit for rTorrent
+- **DISK_QUOTA_IN_GB** – storage quota
+- **TRAFFIC_LIMIT_GB** (optional) – monthly traffic cap
+- **CPUWEIGHT** (optional) – systemd CPU weight (default 1000)
+- **IOWEIGHT** (optional) – systemd IO weight (default 1000)
+
+The script rewrites rTorrent and ruTorrent configs, applies disk quota changes and restarts the user's rTorrent process.
+
+Example:
+```
+/scripts/util/userConfig.php alice 1024 200 750 500 500
+```
+
+**Documentation quality**: Due to the script's length and many TODO comments, more structured documentation would aid maintenance.


### PR DESCRIPTION
## Summary
- document addUser.php usage
- explain the update workflow
- add notes for setupNetwork.php, setupLetsEncrypt.php and userConfig.php

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68729ba070c0832f9be63d1751d62627