### PR TITLE
Add docker help improvements and cron logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@
 # /etc/skel
 !/etc/skel/
 !/etc/skel/*
+!/etc/skel/bin/
+!/etc/skel/bin/**
 !/etc/skel/www/*
 !/etc/skel/www/*/**
 /etc/skel/www/openvpn-config.tgz

--- a/docs/cron.md
+++ b/docs/cron.md
@@ -1,0 +1,14 @@
+# Cron Jobs Overview
+
+The system relies on several cron tasks under `/scripts/cron`.
+A system-wide crontab `/etc/seedbox/config/root.cron` is installed via
+`setupRootCron.php`.
+
+The rootless Docker watchdog `checkRootlessDocker.php` keeps each user's
+Docker daemon running:
+
+```
+*/5 * * * * root /scripts/cron/checkRootlessDocker.php >> /var/log/pmss/rootlessDocker.log 2>&1
+```
+
+Add this line to the root crontab if it is not present.

--- a/docs/docker-help.md
+++ b/docs/docker-help.md
@@ -1,0 +1,34 @@
+# Rootless Docker Basics
+
+Docker runs under each user account without sudo. Useful commands:
+
+```
+systemctl --user start docker.service   # start daemon
+systemctl --user restart docker.service # restart daemon
+docker ps                               # running containers
+docker images                           # downloaded images
+```
+
+Pull images and run containers normally:
+
+```
+docker pull lscr.io/linuxserver/wireguard:latest
+```
+
+A helper script `install-wireguard.sh` resides in `~/bin` for quick setup of the
+linuxserver.io Wireguard container. Invoke it with an optional port:
+
+```
+install-wireguard.sh 51820
+```
+
+
+To ensure Docker commands talk to the correct daemon, the `DOCKER_HOST` environment variable is set in your `~/.bashrc`:
+
+```
+export DOCKER_HOST=unix:///run/user/$(id -u)/docker.sock
+```
+
+If you need docker-compose, download the latest binary into `~/bin` and make it executable. The helper script `install-wireguard.sh` defaults to a random port if none is supplied and prints the chosen port.
+
+See the [rootless Docker limitations](https://docs.docker.com/engine/security/rootless/#known-limitations) for details.

--- a/etc/seedbox/config/root.cron
+++ b/etc/seedbox/config/root.cron
@@ -35,6 +35,7 @@ SHELL=/bin/bash
 
 #*/4 * * * * root /usr/bin/php -q /scripts/cron/checkHttpd.php >> /var/log/pmss/checkHttpd.log 2>&1
 * * * * *   root /scripts/cron/updateQuotas.php >> /var/log/pmss/updateQuotas.log 2>&1
+*/5 * * * * root /scripts/cron/checkRootlessDocker.php >> /var/log/pmss/rootlessDocker.log 2>&1
 */5 * * * *   root    /scripts/cron/trafficLog.php >> /var/log/pmss/trafficLog.log 2>&1
 5 * * * *   root    /scripts/cron/cgroup.php >> /var/log/pmss/cgroup.log 2>&1
 */5 * * * *    root    /scripts/cron/diskIostat.php >> /var/log/pmss/iostatLog.log 2>&1

--- a/etc/seedbox/config/template.motd
+++ b/etc/seedbox/config/template.motd
@@ -29,5 +29,7 @@ LinuxServer.io setup: https://pulsedmedia.com/clients/announcements.php?id=596
 Docker rootless is installed by default for all accounts.
 List Containts Running; `docker ps`
 Restart Docker: `systemctl --user restart docker`
+For usage tips run `docker-help`. The daemon is monitored by a cron job to
+ensure it stays running.
 
 

--- a/etc/skel/.bashrc
+++ b/etc/skel/.bashrc
@@ -110,6 +110,42 @@ fi
 alias arrinfo='echo "RADARR-URL = https://$(hostname)/public-$(whoami)/radarr/" && echo "SONARR-URL = https://$(hostname)/public-$(whoami)/sonarr/" && echo "PROWLARR-URL = https://$(hostname)/public-$(whoami)/prowlarr/" && echo "JELLYFIN-URL = https://$(hostname)/public-$(whoami)/jellyfin/web/index.html" && echo ""'
 alias passwordChange='newPassword=$(< /dev/urandom tr -dc A-NP-Za-km-np-z2-9 | head -c${1:-10};echo;); echo -e "$newPassword\n$newPassword" | passwd $(whoami); htpasswd -b -m $( [ -f ~/.lighttpd/.htpasswd ] || echo -n "-c" ) ~/.lighttpd/.htpasswd $(whoami) $newPassword; echo "New password is: $newPassword"'
 
+# Display rootless Docker usage instructions
+docker-help() {
+  cat <<'EOF'
+Rootless Docker Usage
+=====================
+
+Docker runs in user mode on this system. Useful commands:
+
+    systemctl --user start docker.service   # start daemon
+    systemctl --user restart docker.service # restart daemon
+    docker ps                               # list running containers
+    docker images                           # list downloaded images
+    docker pull IMAGE                       # fetch image
+    docker run IMAGE                        # run container
+
+The environment variable `DOCKER_HOST` points at your user daemon:
+
+    export DOCKER_HOST=unix:///run/user/\$(id -u)/docker.sock
+
+If you require docker-compose, download the latest binary to ~/bin
+and make it executable.
+
+See https://docs.docker.com/engine/security/rootless/ for limitations.
+
+Wireguard container
+-------------------
+Install the linuxserver.io Wireguard container with:
+
+    install-wireguard.sh [PORT]
+
+The script lives in ~/bin and defaults to a random free port if you do not
+specify one. After launch, fetch client configs with
+`docker container exec wireguard /app/show-peer 1`.
+EOF
+}
+
 
 export PATH=~/bin:$PATH
 

--- a/etc/skel/bin/install-wireguard.sh
+++ b/etc/skel/bin/install-wireguard.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Simple installer for the linuxserver.io Wireguard container
+# This is only a basic example. Adjust paths and ports.
+
+PORT=${1:-$(shuf -i 20000-40000 -n 1)}
+CONFIG_DIR="$HOME/.config/docker-wireguard"
+echo "Using port: $PORT"
+
+mkdir -p "$CONFIG_DIR"
+
+docker run -d \
+  --name wireguard \
+  --cap-add NET_ADMIN \
+  --cap-add SYS_MODULE \
+  -e PUID="$(id -u)" \
+  -e PGID="$(id -g)" \
+  -e TZ="$(cat /etc/timezone 2>/dev/null || echo 'UTC')" \
+  -e SERVERURL="$(hostname)" \
+  -e SERVERPORT="$PORT" \
+  -e PEERS=3 \
+  -e PEERDNS=auto \
+  -e INTERNAL_SUBNET=10.13.13.0 \
+  -e ALLOWEDIPS=0.0.0.0/0 \
+  -e LOG_CONFS=true \
+  -v "$CONFIG_DIR":/config \
+  -v /lib/modules:/lib/modules \
+  -p "$PORT":51820/udp \
+  --sysctl net.ipv4.conf.all.src_valid_mark=1 \
+  --restart unless-stopped \
+  lscr.io/linuxserver/wireguard:latest

--- a/scripts/cron/checkRootlessDocker.php
+++ b/scripts/cron/checkRootlessDocker.php
@@ -1,0 +1,23 @@
+#!/usr/bin/php
+<?php
+// Ensure rootless Docker daemon is running for each user
+
+echo date('Y-m-d H:i:s') . ": Checking rootless Docker" . "\n";
+
+$users = explode("\n", trim(shell_exec('/scripts/listUsers.php')));
+
+foreach ($users as $user) {
+    if (empty($user)) continue;
+    if (file_exists("/home/{$user}/www-disabled") || !file_exists("/home/{$user}/www")) {
+        echo "User: {$user} is suspended\n";
+        continue;
+    }
+
+    $status = trim(shell_exec("su {$user} -c 'systemctl --user is-active docker.service 2>/dev/null'"));
+    if ($status !== 'active') {
+        echo "Starting Docker for {$user}\n";
+        passthru("su {$user} -c 'systemctl --user start docker.service' >/dev/null 2>&1");
+    } else {
+        echo "Docker already running for {$user}\n";
+    }
+}


### PR DESCRIPTION
## Summary
- enhance docker-help instructions
- show DOCKER_HOST and compose info in the shell helper
- log when Docker is already running in the cron watchdog

## Testing
- `shellcheck etc/skel/bin/install-wireguard.sh`
- `php -l scripts/cron/checkRootlessDocker.php`


------
https://chatgpt.com/codex/tasks/task_e_6872b2dde82c832fb6ce2d4ebc316977