### PR TITLE
fix(update): hard-kill daemonized ARR version probes

### DIFF
--- a/scripts/lib/tests/development/ArrProbeTimeoutPolicyTest.php
+++ b/scripts/lib/tests/development/ArrProbeTimeoutPolicyTest.php
@@ -6,11 +6,11 @@ require_once dirname(__DIR__, 2).'/update/apps/arr.php';
 
 class ArrProbeTimeoutPolicyTest extends TestCase
 {
-    public function testVersionProbeCommandKeepsProwlarrProbeBounded(): void
+    public function testVersionProbeCommandUsesHardKillAfterGracePeriod(): void
     {
         $command = \pmssArrVersionProbeCommand('/opt/Prowlarr/Prowlarr', '--version');
 
-        $this->assertStringContainsString('timeout 10 ', $command);
+        $this->assertStringContainsString('timeout --kill-after=5 60 ', $command);
         $this->assertStringContainsString("'/opt/Prowlarr/Prowlarr'", $command);
         $this->assertStringContainsString("'--version'", $command);
         $this->assertStringContainsString('2>/dev/null', $command);

--- a/scripts/lib/tests/development/ArrUpdateTest.php
+++ b/scripts/lib/tests/development/ArrUpdateTest.php
@@ -176,7 +176,7 @@ class ArrUpdateTest extends TestCase
 
             $this->assertEquals('existing', (string) @file_get_contents($installPath.'/marker.txt'));
             $timeoutOutput = (string) @file_get_contents($timeoutLog);
-            $this->assertStringContainsString('10 '.($installPath.'/'.$app).' --version', $timeoutOutput);
+            $this->assertStringContainsString('--kill-after=5 60 '.($installPath.'/'.$app).' --version', $timeoutOutput);
             $this->assertStringNotContainsString(' -v', $timeoutOutput, 'expected --version probe to satisfy the version check without a fallback probe');
         } finally {
             $this->cleanup($baseDir);
@@ -209,8 +209,8 @@ class ArrUpdateTest extends TestCase
 
             $this->assertEquals('replacement', (string) @file_get_contents($installPath.'/marker.txt'));
             $timeoutOutput = (string) @file_get_contents($timeoutLog);
-            $this->assertStringContainsString('10 '.($installPath.'/'.$app).' --version', $timeoutOutput);
-            $this->assertStringContainsString('10 '.($installPath.'/'.$app).' -v', $timeoutOutput);
+            $this->assertStringContainsString('--kill-after=5 60 '.($installPath.'/'.$app).' --version', $timeoutOutput);
+            $this->assertStringContainsString('--kill-after=5 60 '.($installPath.'/'.$app).' -v', $timeoutOutput);
         } finally {
             $this->cleanup($baseDir);
         }
@@ -349,6 +349,9 @@ printf '%s\n' "$*" >> "${PMSS_ARR_TEST_TIMEOUT_LOG:?}"
 if [ "${PMSS_ARR_TEST_TIMEOUT_MODE:-pass-through}" = "always-timeout" ]; then
   exit 124
 fi
+while [ "$#" -gt 0 ] && [[ "${1:-}" == --* ]]; do
+  shift
+done
 if [ "$#" -lt 2 ]; then
   exit 125
 fi

--- a/scripts/lib/update/apps/arr.php
+++ b/scripts/lib/update/apps/arr.php
@@ -148,7 +148,7 @@ function pmssArrVersionExtract(string $payload): ?string
 /** Build a bounded ARR version probe so daemonizing binaries cannot wedge updates. */
 function pmssArrVersionProbeCommand(string $binary, string $flag): string
 {
-    return 'timeout 10 '.escapeshellarg($binary).' '.escapeshellarg($flag).' 2>/dev/null';
+    return 'timeout --kill-after=5 60 '.escapeshellarg($binary).' '.escapeshellarg($flag).' 2>/dev/null';
 }
 
 /** Prefer cheap version files, then bounded binary probes, to detect installed ARR versions. */


### PR DESCRIPTION
## Summary
- harden the ARR installed-version probe by adding `timeout --kill-after=5 60`
- keep the probe bounded even when `--version` causes a Starr binary to daemonize and ignore the initial timeout signal
- update ARR timeout policy/update tests so the generated command and shim behavior cover the hard-kill grace period

Closes #527

## Test plan
- `php -l scripts/lib/update/apps/arr.php`
- `php -l scripts/lib/tests/development/ArrProbeTimeoutPolicyTest.php`
- `php -l scripts/lib/tests/development/ArrUpdateTest.php`
- `php scripts/lib/tests/development/Runner.php` (`Tests: 10, Failures: 0, Skipped: 0` in the API-only focused workspace)

<!-- hermes-auto-maintainer -->
